### PR TITLE
Fix Mac OS X + SDL compilation: workarounding two FPC SDL units problems

### DIFF
--- a/gears.pp
+++ b/gears.pp
@@ -26,7 +26,7 @@ unit gears;
 
 interface
 
-uses sysutils,dos,texutil;
+uses sysutils,dos,texutil,math;
 
 Const
 	NumGearStats = 8;	{The number of STAT slots}
@@ -1516,6 +1516,23 @@ end;
 
 
 initialization
+    { Workaround bug in the FPC units SDL_ttf and SDL_image 
+      (see FPC sources, in packages/sdl/src/ ).
+      They miss these $linklib declarations for Mac OS X,
+      and the linker cannot find the appropriate symbols (IMG_Load, various TTF_xxx). }
+    {$if (not defined(ASCII)) and defined(DARWIN)}
+    {$linklib SDL_image}
+    {$linklib SDL_ttf}
+    {$endif}
+    
+    { Looks like SDL on Mac OS X (at least the one installed by HomeBrew) uses OpenGL.
+      As such, it requires the same SetExceptionMask as OpenGL,
+      otherwise it may crash with "invalid floating point operation".
+      Do it here, as early as posssible, before anything can use SDL. }
+    {$if (not defined(ASCII)) and defined(DARWIN) and (defined(cpui386) or defined(cpux86_64))}
+    SetExceptionMask([exInvalidOp, exDenormalized, exZeroDivide,exOverflow, exUnderflow, exPrecision]);
+    {$endif}
+
 	{ Make sure we have the required data directories. }
     if paramcount() > 0 then begin
         Config_Directory := IncludeTrailingPathDelimiter( paramstr(1) );


### PR DESCRIPTION
This workarounds two FPC SDL problems on Mac OS X. I describe Mac OS X compilation of GearHead in details on http://michalis.ii.uni.wroc.pl/~michalis/gearhead_unix/ .

This is equivalent to https://github.com/jwvhewitt/gearhead-1/pull/91 for GearHead 1.