### PR TITLE
Update FSF address to Franklin Street

### DIFF
--- a/ability.pp
+++ b/ability.pp
@@ -21,7 +21,7 @@ unit ability;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/action.pp
+++ b/action.pp
@@ -22,7 +22,7 @@ unit action;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/aibrain.pp
+++ b/aibrain.pp
@@ -19,7 +19,7 @@ unit aibrain;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/arenacfe.pp
+++ b/arenacfe.pp
@@ -18,7 +18,7 @@ unit ArenaCFE;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/arenaplay.pp
+++ b/arenaplay.pp
@@ -18,7 +18,7 @@ unit arenaplay;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/arenascript.pp
+++ b/arenascript.pp
@@ -30,7 +30,7 @@ unit arenascript;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/backpack.pp
+++ b/backpack.pp
@@ -19,7 +19,7 @@ unit backpack;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/beancounter.pas
+++ b/beancounter.pas
@@ -25,7 +25,7 @@ Program beancounter;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/chargen.pp
+++ b/chargen.pp
@@ -19,7 +19,7 @@ unit chargen;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/colormenu.pp
+++ b/colormenu.pp
@@ -18,7 +18,7 @@ unit colormenu;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/customization.pp
+++ b/customization.pp
@@ -18,7 +18,7 @@ unit customization;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/description.pp
+++ b/description.pp
@@ -21,7 +21,7 @@ unit description;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/effects.pp
+++ b/effects.pp
@@ -35,7 +35,7 @@ unit effects;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/fcolor.pas
+++ b/fcolor.pas
@@ -18,7 +18,7 @@ Program fcolor;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/gearhead2.pas
+++ b/gearhead2.pas
@@ -17,7 +17,7 @@ program gearhead2;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 
 {$LONGSTRINGS ON}

--- a/gearparser.pp
+++ b/gearparser.pp
@@ -20,7 +20,7 @@ unit gearparser;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/gears.pp
+++ b/gears.pp
@@ -20,7 +20,7 @@ unit gears;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/gearutil.pp
+++ b/gearutil.pp
@@ -17,7 +17,7 @@ unit gearutil;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/gh2arena.pp
+++ b/gh2arena.pp
@@ -26,7 +26,7 @@ unit gh2arena;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghchars.pp
+++ b/ghchars.pp
@@ -19,7 +19,7 @@ unit ghchars;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghguard.pp
+++ b/ghguard.pp
@@ -18,7 +18,7 @@ unit ghguard;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghholder.pp
+++ b/ghholder.pp
@@ -18,7 +18,7 @@ unit ghholder;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghintrinsic.pp
+++ b/ghintrinsic.pp
@@ -20,7 +20,7 @@ unit ghintrinsic;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghmecha.pp
+++ b/ghmecha.pp
@@ -22,7 +22,7 @@ unit ghmecha;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghmodule.pp
+++ b/ghmodule.pp
@@ -23,7 +23,7 @@ unit ghmodule;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghmovers.pp
+++ b/ghmovers.pp
@@ -19,7 +19,7 @@ unit ghmovers;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghprop.pp
+++ b/ghprop.pp
@@ -23,7 +23,7 @@ unit ghprop;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghsensor.pp
+++ b/ghsensor.pp
@@ -18,7 +18,7 @@ unit ghsensor;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghsupport.pp
+++ b/ghsupport.pp
@@ -27,7 +27,7 @@ unit ghsupport;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghswag.pp
+++ b/ghswag.pp
@@ -20,7 +20,7 @@ unit ghswag;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ghweapon.pp
+++ b/ghweapon.pp
@@ -20,7 +20,7 @@ unit ghweapon;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/grabgear.pp
+++ b/grabgear.pp
@@ -19,7 +19,7 @@ unit grabgear;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/infodisplay.pp
+++ b/infodisplay.pp
@@ -18,7 +18,7 @@ unit infodisplay;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/interact.pp
+++ b/interact.pp
@@ -22,7 +22,7 @@ unit interact;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/license.txt
+++ b/license.txt
@@ -14,8 +14,8 @@ GNU Lesser General Public License
 
 Version 2.1, February 1999 
 
-Copyright (C) 1991, 1999 Free Software Foundation, Inc. 59 Temple Place,
-Suite 330, Boston, MA 02111-1307 USA Everyone is permitted to copy and
+Copyright (C) 1991, 1999 Free Software Foundation, Inc. 51 Franklin Street,
+Fifth Floor, Boston, MA 02110-1301 USA  Everyone is permitted to copy and
 distribute verbatim copies of this license document, but changing it is
 not allowed. 
 
@@ -483,7 +483,7 @@ General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public License
 along with this library; if not, write to the Free Software Foundation,
-Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/locale.pp
+++ b/locale.pp
@@ -21,7 +21,7 @@ unit locale;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/maped.pas
+++ b/maped.pas
@@ -17,7 +17,7 @@ Program maped;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/menugear.pp
+++ b/menugear.pp
@@ -18,7 +18,7 @@ unit menugear;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/minigame.pp
+++ b/minigame.pp
@@ -18,7 +18,7 @@ unit minigame;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/minitype.pp
+++ b/minitype.pp
@@ -19,7 +19,7 @@ unit minitype;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/movement.pp
+++ b/movement.pp
@@ -30,7 +30,7 @@ unit movement;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/mpbuilder.pp
+++ b/mpbuilder.pp
@@ -20,7 +20,7 @@ unit mpbuilder;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/narration.pp
+++ b/narration.pp
@@ -18,7 +18,7 @@ unit narration;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/navigate.pp
+++ b/navigate.pp
@@ -20,7 +20,7 @@ unit navigate;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/pcaction.pp
+++ b/pcaction.pp
@@ -18,7 +18,7 @@ unit pcaction;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/playwright.pp
+++ b/playwright.pp
@@ -20,7 +20,7 @@ unit playwright;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/randmaps.pp
+++ b/randmaps.pp
@@ -33,7 +33,7 @@ unit RandMaps;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/robotics.pp
+++ b/robotics.pp
@@ -19,7 +19,7 @@ unit robotics;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/rpgdice.pp
+++ b/rpgdice.pp
@@ -19,7 +19,7 @@ unit rpgdice;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/scriptbuilder.pas
+++ b/scriptbuilder.pas
@@ -18,7 +18,7 @@ Program scriptbuilder;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 
 {$LONGSTRINGS ON}

--- a/sdlgfx.pp
+++ b/sdlgfx.pp
@@ -17,7 +17,7 @@ unit sdlgfx;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {
 	This is a 2DSD interface for GH2, because acronyms rock.

--- a/sdlinfo.pp
+++ b/sdlinfo.pp
@@ -18,7 +18,7 @@ unit sdlinfo;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/sdlmap.pp
+++ b/sdlmap.pp
@@ -17,7 +17,7 @@ unit sdlmap;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/sdlmenus.pp
+++ b/sdlmenus.pp
@@ -21,7 +21,7 @@ unit sdlmenus;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 
 interface

--- a/services.pp
+++ b/services.pp
@@ -20,7 +20,7 @@ unit services;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/skilluse.pp
+++ b/skilluse.pp
@@ -23,7 +23,7 @@ unit SkillUse;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/spaceships.pp
+++ b/spaceships.pp
@@ -18,7 +18,7 @@ unit spaceships;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/specialsys.pp
+++ b/specialsys.pp
@@ -18,7 +18,7 @@ unit specialsys;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/targetui.pp
+++ b/targetui.pp
@@ -18,7 +18,7 @@ unit targetui;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/texutil.pp
+++ b/texutil.pp
@@ -19,7 +19,7 @@ unit texutil;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/training.pp
+++ b/training.pp
@@ -19,7 +19,7 @@ unit training;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/ui4gh.pp
+++ b/ui4gh.pp
@@ -20,7 +20,7 @@ unit ui4gh;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/vidgfx.pp
+++ b/vidgfx.pp
@@ -17,7 +17,7 @@ unit vidgfx;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/vidinfo.pp
+++ b/vidinfo.pp
@@ -18,7 +18,7 @@ unit vidinfo;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/vidmap.pp
+++ b/vidmap.pp
@@ -17,7 +17,7 @@ unit vidmap;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/vidmenus.pp
+++ b/vidmenus.pp
@@ -20,7 +20,7 @@ unit vidmenus;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 

--- a/wmonster.pp
+++ b/wmonster.pp
@@ -17,7 +17,7 @@ unit WMonster;
 
 	You should have received a copy of the GNU Lesser General Public License
 	along with this library; if not, write to the Free Software Foundation,
-	Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 }
 {$LONGSTRINGS ON}
 


### PR DESCRIPTION
License headers in code files, as well as `license.txt`, use the outdated FSF address at Temple Place. This patch updates all occurrences to the current address, taken from: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt